### PR TITLE
Add independent disk capabilities

### DIFF
--- a/lib/vcloud-rest/connection.rb
+++ b/lib/vcloud-rest/connection.rb
@@ -30,6 +30,7 @@ require 'vcloud-rest/vcloud/vm'
 require 'vcloud-rest/vcloud/ovf'
 require 'vcloud-rest/vcloud/media'
 require 'vcloud-rest/vcloud/network'
+require 'vcloud-rest/vcloud/disk'
 
 module VCloudClient
   class UnauthorizedAccess < StandardError; end

--- a/lib/vcloud-rest/vcloud/disk.rb
+++ b/lib/vcloud-rest/vcloud/disk.rb
@@ -1,0 +1,109 @@
+module VCloudClient
+  class Connection
+
+    def create_disk(name, size, vdc_id, description="")
+
+      builder = Nokogiri::XML::Builder.new do |xml|
+        xml.DiskCreateParams(
+          "xmlns" => "http://www.vmware.com/vcloud/v1.5") {
+          xml.Disk("name" => name, "size" => size) {
+            xml.Description description
+          }
+        }
+      end
+
+      params = {
+        'method' => :post,
+        'command' => "/vdc/#{vdc_id}/disk"
+      }
+
+      @logger.debug "Creating independent disk #{name} in VDC #{vdc_id}"
+      response, headers = send_request(params, builder.to_xml, "application/vnd.vmware.vcloud.diskCreateParams+xml")
+
+      # Get the id of the new disk
+      disk_url = response.css("Disk").first[:href]
+      disk_id = disk_url.gsub(/.*\/disk\//, "")
+      @logger.debug "Independent disk created = #{disk_id}"
+
+      task = response.css("Task[operationName='vdcCreateDisk']").first
+      task_id = task["href"].gsub(/.*\/task\//, "")
+
+      { :disk_id => disk_id, :task_id => task_id }
+    end
+
+    def get_disk(disk_id)
+
+      params = {
+        'method' => :get,
+        'command' => "/disk/#{disk_id}"
+      }
+
+      @logger.debug "Fetching independent disk #{disk_id}"
+      response, headers = send_request(params)
+
+      name = response.css("Disk").attribute("name").text
+      size = response.css("Disk").attribute("size").text
+      description = response.css("Description").first
+      description = description.text unless description.nil?
+      storage_profile = response.css("StorageProfile").first[:name]
+      owner = response.css("User").first[:name]
+      { :id => disk_id, :name => name, :size => size, :description => description, :storage_profile => storage_profile, :owner => owner }
+    end
+
+    def get_disk_by_name(organization, vdcName, diskName)
+      result = nil
+
+      get_vdc_by_name(organization, vdcName)[:disks].each do |disk|
+        if disk[0].downcase == diskName.downcase
+          result = get_disk(disk[1])
+        end
+      end
+
+      result
+    end
+
+    def attach_disk_to_vm(disk_id, vm_id)
+      disk_attach_action(disk_id, vm_id, 'attach')
+    end
+
+    def detach_disk_from_vm(disk_id, vm_id)
+      disk_attach_action(disk_id, vm_id, 'detach')
+    end
+
+    def delete_disk(disk_id)
+      params = {
+        'method' => :delete,
+        'command' => "/disk/#{disk_id}"
+      }
+
+      @logger.debug "Deleting independent disk #{disk_id}"
+      response, headers = send_request(params)
+
+      task = response.css("Task").first
+      task_id = task["href"].gsub(/.*\/task\//, "")      
+    end
+
+    private
+
+    def disk_attach_action(disk_id, vm_id, action)
+      builder = Nokogiri::XML::Builder.new do |xml|
+        xml.DiskAttachOrDetachParams("xmlns" => "http://www.vmware.com/vcloud/v1.5") {
+          xml.Disk(
+            "type" => "application/vnd.vmware.vcloud.disk+xml",
+            "href" => "#{@api_url}/disk/#{disk_id}")
+        }
+      end
+
+      params = {
+        'method' => :post,
+        'command' => "/vApp/vm-#{vm_id}/disk/action/#{action}"
+      }
+      
+      response, headers = send_request(params, builder.to_xml, "application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml")
+
+      task = response.css("Task").first
+      task_id = task["href"].gsub(/.*\/task\//, "")
+    end
+
+  end
+end

--- a/lib/vcloud-rest/vcloud/vdc.rb
+++ b/lib/vcloud-rest/vcloud/vdc.rb
@@ -4,6 +4,8 @@ module VCloudClient
     # Fetch details about a given vdc:
     # - description
     # - vapps
+    # - templates
+    # - disks
     # - networks
     def get_vdc(vdcId)
       params = {
@@ -24,12 +26,24 @@ module VCloudClient
         vapps[item['name']] = item['href'].gsub(/.*\/vApp\/vapp\-/, "")
       end
 
+      templates = {}
+      response.css("ResourceEntity[type='application/vnd.vmware.vcloud.vAppTemplate+xml']").each do |item|
+        templates[item['name']] = item['href'].gsub(/.*\/vAppTemplate\/vappTemplate\-/, "")
+      end
+
+      disks = {}
+      response.css("ResourceEntity[type='application/vnd.vmware.vcloud.disk+xml']").each do |item|
+        disks[item['name']] = item['href'].gsub(/.*\/disk\//, "")
+      end
+
       networks = {}
       response.css("Network[type='application/vnd.vmware.vcloud.network+xml']").each do |item|
         networks[item['name']] = item['href'].gsub(/.*\/network\//, "")
       end
+
       { :id => vdcId, :name => name, :description => description,
-        :vapps => vapps, :networks => networks }
+        :vapps => vapps, :templates => templates, :disks => disks,
+        :networks => networks }
     end
 
     ##


### PR DESCRIPTION
Independent disks are available to use only through the api in 5.1, not
the console.  Added methods to create, query, attach to a vm, detach,
and delete.
