### PR TITLE
Fixed network adding to a VM for API v. 5.5

### DIFF
--- a/lib/vcloud-rest/vcloud/vm.rb
+++ b/lib/vcloud-rest/vcloud/vm.rb
@@ -186,8 +186,9 @@ module VCloudClient
       # For some reasons these elements must be removed
       netconfig_response.css("Link").each {|n| n.remove}
 
-      # Delete placeholder network
-      netconfig_response.css('NetworkConnection').find{|n| n.attribute('network').text == 'none'}.remove
+      # Delete placeholder network if present (since vcloud 5.5 has been removed)
+      none_network = netconfig_response.css('NetworkConnection').find{|n| n.attribute('network').text == 'none'}
+      none_network.remove if none_network
 
       networks_count = netconfig_response.css('NetworkConnection').count
 


### PR DESCRIPTION
/vApp/vm-#{vmId}/networkConnectionSection API does not contain none network annymore.
It has to be removed only if present.
This change is not documented in official doc and release notes.
