### PR TITLE
Fixed upload_ovf to raise an excption if ovfFile has not .ovf extension

### DIFF
--- a/lib/vcloud-rest/vcloud/ovf.rb
+++ b/lib/vcloud-rest/vcloud/ovf.rb
@@ -10,6 +10,7 @@ module VCloudClient
     # - uploadOptions {}
     def upload_ovf(vdcId, vappName, vappDescription, ovfFile, catalogId, uploadOptions={})
       raise ::IOError, "OVF #{ovfFile} is missing." unless File.exists?(ovfFile)
+      raise ::IOError, "Only .ovf files are supported" unless File.extname(ovfFile) =~ /\.ovf/ 
 
       # if send_manifest is not set, setting it true
       if uploadOptions[:send_manifest].nil? || uploadOptions[:send_manifest]


### PR DESCRIPTION
No check was present to avoid uploading of a file different from ovf.
If a different file was uploaded (for example .ova) application/vnd.vmware.vcloud.uploadVAppTemplateParams API would be completed, but subsequent 'upload_file' execution would fail.
ToDo: verify how to upload ova.
