### PR TITLE
Added acquire_ticket_vm API to retrieve a screen ticket for VMRC browser plugin

### DIFF
--- a/lib/vcloud-rest/connection.rb
+++ b/lib/vcloud-rest/connection.rb
@@ -21,6 +21,7 @@ require 'nokogiri'
 require 'httpclient'
 require 'ruby-progressbar'
 require 'logger'
+require 'uri'
 
 require 'vcloud-rest/vcloud/vapp'
 require 'vcloud-rest/vcloud/org'

--- a/lib/vcloud-rest/vcloud/vm.rb
+++ b/lib/vcloud-rest/vcloud/vm.rb
@@ -472,6 +472,28 @@ module VCloudClient
       discard_snapshot_action(vmId, :vm)
     end
 
+    ##
+    # Retrieve a screen ticket that you can use with the VMRC browser plug-in
+    # to gain access to the console of a running VM.
+    def acquire_ticket_vm(vmId)
+
+      params = {
+        'method' => :post,
+        'command' => "/vApp/vm-#{vmId}/screen/action/acquireTicket"
+      }
+
+      response, headers = send_request(params)
+
+      screen_ticket = response.css("ScreenTicket").text
+
+      if screen_ticket =~ /mks:\/\/([^\/]*)\/([^\?]*)\?ticket=(.*)/
+        { host: $1, moid: $2, token: $3 }
+      else
+        {}
+      end
+
+    end
+
     private
       def add_disk(source_xml, disk_info)
 


### PR DESCRIPTION
Added acquire_ticket_vm API to retrieve a screen ticket for VMRC browser plugin
- API Documentation:
  
  http://pubs.vmware.com/vcd-55/index.jsp#com.vmware.vcloud.api.doc_55/GUID-0DF63045-16D7-49E7-878E-B56E27F99C62.html
  
  http://pubs.vmware.com/vcd-55/index.jsp?topic=%2Fcom.vmware.vcloud.api.reference.doc_55%2Fdoc%2Foperations%2FPOST-AcquireTicket.html
- Implementation example:
  https://www.vmware.com/support/vcd/doc/vcd-1.5-vmrc-api-example.zip
- VMRC documentation:
  https://www.vmware.com/pdf/vcd_15_vmrc_api.pdf
