### PR TITLE
Fix nil when deleting vapp.

### DIFF
--- a/lib/vcloud-rest/vcloud/vapp.rb
+++ b/lib/vcloud-rest/vcloud/vapp.rb
@@ -34,8 +34,8 @@ module VCloudClient
 
       networks = response.css('NetworkConfig').reject{|n| n.attribute('networkName').text == 'none'}.
         collect do |network|
-          net_id = network.css('Link [rel=repair]')
-          net_id = net_id.attribute('href').text.gsub(/.*\/network\/(.*)\/action.*/, '\1') unless net_id.nil?
+          net_id = network.css('Link[rel=repair]')
+          net_id = net_id.attribute('href').text.gsub(/.*\/network\/(.*)\/action.*/, '\1') unless net_id.empty?
 
           net_name = network.attribute('networkName').text
 

--- a/lib/vcloud-rest/vcloud/vm.rb
+++ b/lib/vcloud-rest/vcloud/vm.rb
@@ -11,7 +11,7 @@ module VCloudClient
       response, headers = send_request(params)
 
       result = {}
-      response.css("ovf|Item [vcloud|href]").each do |item|
+      response.css("ovf|Item[vcloud|href]").each do |item|
         item_name = item.attribute('href').text.gsub(/.*\/vApp\/vm\-(\w+(-?))+\/virtualHardwareSection\//, "")
         name = item.css("rasd|ElementName")
         name = name.text unless name.nil?


### PR DESCRIPTION
I got this error when trying to delete a vapp. net_id was an empty NodeSet, it wasn't nil.

```
/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/nokogiri-1.6.4.1/lib/nokogiri/xml/node_set.rb:214:in `attr': undefined method `attribute' for nil:NilClass (NoMethodError)
    from /Users/joaovale/.chefdk/gem/ruby/2.1.0/gems/vcloud-rest-1.3.0/lib/vcloud-rest/vcloud/vapp.rb:42:in `block in get_vapp'
    from /Users/joaovale/.chefdk/gem/ruby/2.1.0/gems/vcloud-rest-1.3.0/lib/vcloud-rest/vcloud/vapp.rb:36:in `collect'
    from /Users/joaovale/.chefdk/gem/ruby/2.1.0/gems/vcloud-rest-1.3.0/lib/vcloud-rest/vcloud/vapp.rb:36:in `get_vapp'
    from /Users/joaovale/.chefdk/gem/ruby/2.1.0/gems/vcloud-rest-1.3.0/lib/vcloud-rest/vcloud/vapp.rb:127:in `block in get_vapp_by_name'
    from /Users/joaovale/.chefdk/gem/ruby/2.1.0/gems/vcloud-rest-1.3.0/lib/vcloud-rest/vcloud/vapp.rb:125:in `each'
    from /Users/joaovale/.chefdk/gem/ruby/2.1.0/gems/vcloud-rest-1.3.0/lib/vcloud-rest/vcloud/vapp.rb:125:in `get_vapp_by_name'
    from /Users/joaovale/.chefdk/gem/ruby/2.1.0/gems/knife-vcloud-1.3.0/lib/chef/knife/common/vc_vapp_common.rb:42:in `get_vapp'
    from /Users/joaovale/.chefdk/gem/ruby/2.1.0/gems/knife-vcloud-1.3.0/lib/chef/knife/vapp/vc_vapp_delete.rb:34:in `run'
    from /opt/chefdk/embedded/apps/chef/lib/chef/knife.rb:493:in `run_with_pretty_exceptions'
    from /opt/chefdk/embedded/apps/chef/lib/chef/knife.rb:174:in `run'
    from /opt/chefdk/embedded/apps/chef/lib/chef/application/knife.rb:139:in `run'
    from /opt/chefdk/embedded/apps/chef/bin/knife:25:in `<top (required)>'
    from /usr/bin/knife:34:in `load'
    from /usr/bin/knife:34:in `<main>'
```
