### PR TITLE
Added an optional parameter to the Connection#initliaze for the SSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ tmp
 Gemfile.lock
 .ruby-version
 .ruby-gemset
+.idea/
 
 # YARD artifacts
 .yardoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changes
 
+### 2016-06-07 (1.4.1)
+
+**Features**
+
+* Added an optional parameter to the Connection#initliaze for the SSL mode.  Useful for testing vCloud Director in a lab environment when a real SSL cert is not available.
+
+Normal connection setup:
+
+    connection = VCloudClient::Connection.new(host, user, pass, org, api)
+    
+Disable SSL certificate check:
+
+    connection = VCloudClient::Connection.new(host, user, pass, org, api, OpenSSL::SSL::VERIFY_NONE)
+    
 ### 2015-06-28 (1.4.0)
 
 Note that I don't have enough time anymore to actively maintain this gem and I'm

--- a/lib/vcloud-rest/connection.rb
+++ b/lib/vcloud-rest/connection.rb
@@ -49,7 +49,7 @@ module VCloudClient
     attr_reader :api_url, :auth_key
     attr_reader :extensibility
 
-    def initialize(host, username, password, org_name, api_version)
+    def initialize(host, username, password, org_name, api_version, verify_ssl=true)
       @host = host
       @api_url = "#{host}/api"
       @host_url = "#{host}"
@@ -57,6 +57,7 @@ module VCloudClient
       @password = password
       @org_name = org_name
       @api_version = (api_version || "5.1")
+      @verify_ssl = verify_ssl
 
       init_logger
     end
@@ -161,7 +162,7 @@ module VCloudClient
       end
 
       def setup_request(params, payload=nil, content_type=nil)
-        req_params = {:method => params['method'],
+        req_params = {:method => params['method'], :verify_ssl => @verify_ssl,
                       :headers => {:accept => "application/*+xml;version=#{@api_version}"},
                       :url => "#{@api_url}#{params['command']}",
                       :payload => payload}

--- a/lib/vcloud-rest/version.rb
+++ b/lib/vcloud-rest/version.rb
@@ -1,3 +1,3 @@
 module VCloudClient
-  VERSION = "1.4.0"
+  VERSION = "1.4.1"
 end


### PR DESCRIPTION
Useful for testing vCloud Director in a lab environment when a real SSL cert is not available.
